### PR TITLE
Upgrade Cake to 0.17.0

### DIFF
--- a/Cake.VersionReader/Cake.VersionReader.Test/Cake.VersionReader.Tests.csproj
+++ b/Cake.VersionReader/Cake.VersionReader.Test/Cake.VersionReader.Tests.csproj
@@ -30,8 +30,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.10.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.10.1\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Cake.Testing, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Testing.0.17.1\lib\net45\Cake.Testing.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/Cake.VersionReader/Cake.VersionReader.Test/Fakes/FakeCakeContext.cs
+++ b/Cake.VersionReader/Cake.VersionReader.Test/Fakes/FakeCakeContext.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Cake.Core;
 using Cake.Core.IO;
+using Cake.Core.Tooling;
+using Cake.Testing;
 
 namespace Cake.VersionReader.Tests.Fakes
 {
@@ -16,14 +18,16 @@ namespace Cake.VersionReader.Tests.Fakes
                 System.IO.Path.GetFullPath (AppDomain.CurrentDomain.BaseDirectory));
             
             var fileSystem = new FileSystem ();
-            var environment = new CakeEnvironment ();
+            _log = new FakeLog();
+            var environment = new CakeEnvironment (new CakePlatform(), new CakeRuntime(), _log);
             var globber = new Globber (fileSystem, environment);
-            _log = new FakeLog ();
+            
             var args = new FakeCakeArguments ();
             var processRunner = new ProcessRunner (environment, _log);
             var registry = new WindowsRegistry ();
 
-            _context = new CakeContext (fileSystem, environment, globber, _log, args, processRunner, registry);
+            var toolLocator = new ToolLocator(environment, new ToolRepository(environment), new ToolResolutionStrategy(fileSystem, environment, globber, new FakeConfiguration()));
+            _context = new CakeContext (fileSystem, environment, globber, _log, args, processRunner, registry, toolLocator);
             _context.Environment.WorkingDirectory = _testsDir;
         }
 

--- a/Cake.VersionReader/Cake.VersionReader.Test/Fakes/FakeLog.cs
+++ b/Cake.VersionReader/Cake.VersionReader.Test/Fakes/FakeLog.cs
@@ -26,7 +26,11 @@ namespace Cake.VersionReader.Tests.Fakes
         /// Gets the verbosity.
         /// </summary>
         /// <value>The verbosity.</value>
-        public Verbosity Verbosity => Verbosity.Diagnostic;
+        public Verbosity Verbosity
+        {
+            get { return Verbosity.Diagnostic; }
+            set { }
+        }
 
         /// <summary>
         /// Writes the text representation of the specified array of objects to the

--- a/Cake.VersionReader/Cake.VersionReader.Test/packages.config
+++ b/Cake.VersionReader/Cake.VersionReader.Test/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.10.1" targetFramework="net46" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net46" />
+  <package id="Cake.Testing" version="0.17.1" targetFramework="net46" />
   <package id="NUnit" version="3.2.1" targetFramework="net46" />
 </packages>

--- a/Cake.VersionReader/Cake.VersionReader/Cake.VersionReader.csproj
+++ b/Cake.VersionReader/Cake.VersionReader/Cake.VersionReader.csproj
@@ -41,8 +41,8 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.10.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.10.1\lib\net45\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.17.0\lib\net45\Cake.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Cake.VersionReader/Cake.VersionReader/packages.config
+++ b/Cake.VersionReader/Cake.VersionReader/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.10.1" targetFramework="net45" />
+  <package id="Cake.Core" version="0.17.0" targetFramework="net45" />
   <package id="SemVer.Git.MSBuild" version="1.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Cake 0.18.0 will requires at least version 0.16.x to work.