### PR TITLE
Update Cake.Core to 0.26.0 for net46

### DIFF
--- a/Cake.VersionReader/Cake.VersionReader.nuspec
+++ b/Cake.VersionReader/Cake.VersionReader.nuspec
@@ -23,7 +23,7 @@
             <dependency id="Cake.Core" version="0.17.0" />
         </group>
         <group targetFramework="net46">
-            <dependency id="Cake.Core" version="0.22.0" />
+            <dependency id="Cake.Core" version="0.26.0" />
         </group>
       </dependencies>
    </metadata>

--- a/Cake.VersionReader/Cake.VersionReader/Cake.VersionReader.csproj
+++ b/Cake.VersionReader/Cake.VersionReader/Cake.VersionReader.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.22.0" Condition="'$(TargetFramework)' == 'net46'" />
+    <PackageReference Include="Cake.Core" Version="0.26.0" Condition="'$(TargetFramework)' == 'net46'" />
     <PackageReference Include="Cake.Core" Version="0.17.0" Condition="'$(TargetFramework)' == 'net45'" />
     <PackageReference Include="SemVer.Git.MSBuild" Version="1.1.0" />
   </ItemGroup>


### PR DESCRIPTION
The current release causes verification errors when used with the latest version of Cake. Updating the version of Cake.Core should resolve that.

I've only updated the version for the net46 build - and also left the version in the test project at 0.17.0. Is that correct?

Thanks for sharing this tool! 😄 